### PR TITLE
Fix listener order index calculation

### DIFF
--- a/Runtime/Common/DAction.cs
+++ b/Runtime/Common/DAction.cs
@@ -128,11 +128,11 @@ namespace DSystem
         {
             var attr = AssemblyDataCacher.GetEventListenerAttribute(t.GetType());
             if (attr == null)
-                return short.MaxValue;
-            
-            int order = short.MaxValue;
-            order |= (int)attr.ListenerFlags << 16;
-            return order;
+                return ushort.MaxValue;
+
+            var flags = (int)attr.ListenerFlags;
+            var order = attr.Order - short.MinValue;
+            return (flags << 16) | order;
         }
 
         public void RemoveListener(T listener)

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,9 @@
 ### Improvement
 - Add `EventListenerAttribute` for ordering listeners.
 
+### Fixed
+- Correct listener order index calculation in `DAction`.
+
 ## [2.6.4] - 2025-06-11
 
 ### Fixed


### PR DESCRIPTION
## Summary
- compute listener sort index using flags and per-category order
- document change in changelog

## Testing
- `npm test` *(fails: Missing script "test")*
- `dotnet test` *(fails: no project or solution file)*

------
https://chatgpt.com/codex/tasks/task_e_6895ba4710d0832a8a4371fc0ed295b8